### PR TITLE
[spam]

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/inspect-js/is-symbol.git"
+		"url": "git+https://github.com/inspect-js/is-symbol.git"
 	},
 	"keywords": [
 		"symbol",


### PR DESCRIPTION
The `repository` field in `package.json` currently uses an unauthenticated or SSH git URL. This requires package consumers and registry tools to have authenticated SSH GitHub access or unblocked git protocols to resolve the repository metadata.

This PR updates it to an HTTPS URL (`git+https://github.com/...`) which is publicly accessible and standard for npm packages.